### PR TITLE
chore: upgrade aws-cdk and aws-cdk-lib

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cdk",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "^2.115.0",
+        "aws-cdk-lib": "^2.185.0",
         "cdk-nag": "^2.27.223",
         "constructs": "^10.0.0",
         "source-map-support": "^0.5.21"
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@types/jest": "^29.5.11",
         "@types/node": "20.10.4",
-        "aws-cdk": "^2.115.0",
+        "aws-cdk": "^2.1005.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.2",
@@ -41,15 +41,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.221",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.221.tgz",
-      "integrity": "sha512-+Vu2cMvgtkaHwNezrTVng4+FAMAWKJTkC/2ZQlgkbY05k0lHHK/2eWKqBhTeA7EpxVrx9uFN7GdBFz3mcThpxg==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@aws-cdk/asset-kubectl-v20": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.3.tgz",
-      "integrity": "sha512-cDG1w3ieM6eOT9mTefRuTypk95+oyD7P5X/wRltwmYxU7nZc3+076YEVS6vrjDKr3ADYbfn0lDKpfB1FBtO9CQ==",
+      "version": "2.2.229",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.229.tgz",
+      "integrity": "sha512-apNt/Sfty7Jwi1+6hrZaQeVisqnJAW4+uQZI55VPKtBqjTFEsKPBc/KZDx9Tlw8Ii1yWrS3HNzLNGxpTXae8XQ==",
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
@@ -59,9 +53,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
-      "version": "39.2.9",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-39.2.9.tgz",
-      "integrity": "sha512-Ao4C8WoM5wgU4yn0aKLvI4gtgiRDa+8bVVwOlhGK9/jHmZlgMZY44UY9muq6qMKsMXTmfQeaB8LS3JLOiEUheA==",
+      "version": "40.7.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-40.7.0.tgz",
+      "integrity": "sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==",
       "bundleDependencies": [
         "jsonschema",
         "semver"
@@ -69,7 +63,10 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
-        "semver": "^7.7.0"
+        "semver": "^7.7.1"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
@@ -81,7 +78,7 @@
       }
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
-      "version": "7.7.0",
+      "version": "7.7.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1262,9 +1259,9 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
-      "version": "2.177.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.177.0.tgz",
-      "integrity": "sha512-TiBoyE5wMB5q4jX1bELwkklgbs5eLY1Phjfnb4Mof0K9tOSRJ9UEq6xEamF0esMS+TuYU7a/ESTpmKX3iYqA3w==",
+      "version": "2.1005.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1005.0.tgz",
+      "integrity": "sha512-4ejfGGrGCEl0pg1xcqkxK0lpBEZqNI48wtrXhk6dYOFYPYMZtqn1kdla29ONN+eO2unewkNF4nLP1lPYhlf9Pg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1278,9 +1275,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.177.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.177.0.tgz",
-      "integrity": "sha512-nTnHAwjZaPJ5gfJjtzE/MyK6q0a66nWthoJl7l8srucRb+I30dczhbbXor6QCdVpJaTRAEliMOMq23aglsAQbg==",
+      "version": "2.185.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.185.0.tgz",
+      "integrity": "sha512-RNcQeNnInumDF1hq3gAf+/A6jhvYDof5a7418gEs/y6359gTYZpTCQkgItC50iV3MmkgerrBAdOE7CDEtQNDWw==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1296,20 +1293,19 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.208",
-        "@aws-cdk/asset-kubectl-v20": "^2.1.3",
+        "@aws-cdk/asset-awscli-v1": "^2.2.227",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
-        "@aws-cdk/cloud-assembly-schema": "^39.2.0",
+        "@aws-cdk/cloud-assembly-schema": "^40.7.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.2.0",
+        "fs-extra": "^11.3.0",
         "ignore": "^5.3.2",
-        "jsonschema": "^1.4.1",
+        "jsonschema": "^1.5.0",
         "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.6.3",
-        "table": "^6.8.2",
+        "semver": "^7.7.1",
+        "table": "^6.9.0",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -1423,12 +1419,22 @@
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
-      "version": "3.0.3",
+      "version": "3.0.6",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.2.0",
+      "version": "11.3.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1478,7 +1484,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
-      "version": "1.4.1",
+      "version": "1.5.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -1537,7 +1543,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.6.3",
+      "version": "7.7.1",
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -1588,7 +1594,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.2",
+      "version": "6.9.0",
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -1738,12 +1744,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -1983,6 +1991,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/constructs": {
@@ -3507,6 +3516,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -13,14 +13,14 @@
   "devDependencies": {
     "@types/jest": "^29.5.11",
     "@types/node": "20.10.4",
-    "aws-cdk": "^2.115.0",
+    "aws-cdk": "^2.1005.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "typescript": "~5.3.3"
   },
   "dependencies": {
-    "aws-cdk-lib": "^2.115.0",
+    "aws-cdk-lib": "^2.185.0",
     "cdk-nag": "^2.27.223",
     "constructs": "^10.0.0",
     "source-map-support": "^0.5.21"

--- a/cdk/test/__snapshots__/cdk.test.ts.snap
+++ b/cdk/test/__snapshots__/cdk.test.ts.snap
@@ -50,10 +50,10 @@ exports[`Snapshot test 1`] = `
         "value": "nodejs20.x",
       },
       "cn-north-1": {
-        "value": "nodejs18.x",
+        "value": "nodejs20.x",
       },
       "cn-northwest-1": {
-        "value": "nodejs18.x",
+        "value": "nodejs20.x",
       },
       "eu-central-1": {
         "value": "nodejs20.x",
@@ -104,10 +104,10 @@ exports[`Snapshot test 1`] = `
         "value": "nodejs20.x",
       },
       "us-gov-east-1": {
-        "value": "nodejs18.x",
+        "value": "nodejs20.x",
       },
       "us-gov-west-1": {
-        "value": "nodejs18.x",
+        "value": "nodejs20.x",
       },
       "us-iso-east-1": {
         "value": "nodejs18.x",
@@ -313,7 +313,7 @@ exports[`Snapshot test 1`] = `
           "S3Bucket": {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "b222f755382b5b2cc93040db74cfcd74e7ac8aabff0a3a70e3d1c0f20bc8c014.zip",
+          "S3Key": "b585179dc46d9100f31367c1eb03e063c4e1a396f99a6a188ac4a05a16ae4fa5.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,


### PR DESCRIPTION
このPRでは以下の依存関係をアップグレードしました：\n\n- aws-cdk: ^2.115.0 → ^2.1005.0\n- aws-cdk-lib: ^2.115.0 → ^2.185.0\n\npackage.jsonとpackage-lock.jsonの両方を更新しています。